### PR TITLE
Adding vendor form

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,43 +54,21 @@ def index():
 @app.route('/signup', methods=['GET', 'POST'])
 def signup():
     if request.method == 'POST': #is user signing up
-        username=request.form['username']
-        password=request.form['password']
-        verify=request.form['verify']
+        form = request.form
+        username = form['username']
+        password = form['password']
+        verify = form['verify']
+        register_type = 'organizer'
+
+        if 'vendor_signup' in form:
+            print("Vendor Signup")
+            register_type = 'vendor'
+
+        # XXX Not sure if we need this
         # name=request.form['name']
         # phoneNumber=request.form['phoneNumber']
         # current_users = User.query.filter_by(username = username).first()
 
-        if password == '':
-            flash('Please enter a password', 'error')
-            return redirect('/signup')
-        if username == '':
-            flash('Please enter an email for your username', 'error')
-            return redirect('/signup')
-        # Check if is valid email
-        if not re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", username):
-            flash("Username must be a valid email", 'error')
-            return redirect('/signup')
-        # Check if passwords match
-        if password != verify:
-            flash("Password and verify password don't match", 'error')
-            return redirect('/signup')
-        # Check if password has a minimum length of 8 characters
-        if len(password) < 8:
-            flash("Password must be at least 8 characters long", 'error')
-            return redirect('/signup')
-        # Check if contains at least one digit
-        if not re.search(r'\d', password):
-            flash("Password must contain at least one number", 'error')
-            return redirect('/signup')
-        # Check if contains at least one uppercase letter
-        if not re.search(r'[A-Z]', password):
-            flash("Password must contain at least one uppercase letter.", 'error')
-            return redirect('/signup')
-        # Check if contains at least one lowercase letter
-        if not re.search(r'[a-z]', password):
-            flash("Password must contain at least one lowercase letter.", 'error')
-            return redirect('/signup')
         # if name == '':
         #     flash('Please enter your name', 'error')
         #     return redirect('/signup')
@@ -101,12 +79,50 @@ def signup():
         #     if username in current_users:
         #         flash("Duplicate user", 'error')
         #         return redirect('/signup')
+
+        if password == '':
+            flash('Please enter a password', 'pass_error')
+            return redirect('/signup')
+        if username == '':
+            flash('Please enter an email for your username', 'user_error')
+            return redirect('/signup')
+        # Check if is valid email
+        if not re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", username):
+            flash("Username must be a valid email", 'user_error')
+            return redirect('/signup')
+        # Check if passwords match
+        if password != verify:
+            flash("Password and verify password don't match", 'verify_error')
+            return redirect('/signup')
+        # Check if password has a minimum length of 8 characters
+        if len(password) < 8:
+            flash("Password must be at least 8 characters long", 'pass_error')
+            return redirect('/signup')
+        # Check if contains at least one digit
+        if not re.search(r'\d', password):
+            flash("Password must contain at least one number", 'pass_error')
+            return redirect('/signup')
+        # Check if contains at least one uppercase letter
+        if not re.search(r'[A-Z]', password):
+            flash("Password must contain at least one uppercase letter.", 'pass_error')
+            return redirect('/signup')
+        # Check if contains at least one lowercase letter
+        if not re.search(r'[a-z]', password):
+            flash("Password must contain at least one lowercase letter.", 'pass_error')
+            return redirect('/signup')
+
+        # TODO This is basic, needs to expand to what the coulmns actually are
+        if register_type == 'organizer':
+            new_user = User(username, password)
         else:
-            new_user=User(username, password)
-            # db.session.add(new_user)
-            # db.session.commit()
-            session['username'] = username
-        return render_template('testSignup.html')
+            new_user = Vendor(username, password)
+
+        print(register_type)
+        # db.session.add(new_user)
+        # db.session.commit()
+        session['username'] = username
+        # Create a login function to auto login the user based on register_type (vendor/organizer)
+        return render_template('verify_email.html')
 
 
     return render_template('signup.html')

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -63,9 +63,6 @@ div.wrapper h1{
   color: #33B8F7;
   text-decoration: none;
 }
-.vendor-only{
-  display: none;
-}
 
 .signup-field {
     width: 290px;

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -10,6 +10,7 @@ div.wrapper {
     display: flex;
     height: -webkit-calc(100vh - 57px);
     height: calc(100vh - 57px);
+    flex-flow: column;
     margin: auto;
     -webkit-box-pack: center;
     -webkit-justify-content: center;
@@ -19,6 +20,9 @@ div.wrapper {
     -webkit-align-items: center;
         -ms-flex-align: center;
             align-items: center;
+}
+div.wrapper h1{
+  margin-bottom: 1em;
 }
 
 .signup-container {
@@ -33,6 +37,34 @@ div.wrapper {
     background-color: white;
     -webkit-box-shadow: 0 0 4px #9c9c9c;
             box-shadow: 0 0 4px #9c9c9c;
+}
+
+.signup-tabs{
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  justify-content: center;
+}
+.vendor-signup{
+  display: none;
+}
+.toggle-form{
+  font-size: 2rem;
+  margin: 0 1rem;
+  color: #9e9e9e;
+  cursor: pointer;
+  text-decoration: none;
+}
+.toggle-form:hover{
+  color: #B3E5FC;
+  text-decoration: none;
+}
+.active-form{
+  color: #33B8F7;
+  text-decoration: none;
+}
+.vendor-only{
+  display: none;
 }
 
 .signup-field {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css?family=Lato');
 body {
     height: 100%;
     margin: 0;
@@ -10,7 +11,7 @@ body {
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
-    font-family: 'Playfair Display', serif;
+    font-family: 'Lato', 'Playfair Display', serif;
 }
 
 p{
@@ -39,7 +40,7 @@ p{
 #venue{
     text-align: center;
     background-image: url("../images/venue.jpg");
-    background-position: center; 
+    background-position: center;
     opacity: 0.7;
 }
 
@@ -49,7 +50,7 @@ p{
 
 #photographer{
     background-image: url("../images/photographer.jpg");
-    background-position: center; 
+    background-position: center;
     opacity: 0.7;
 }
 
@@ -60,7 +61,7 @@ p{
 #video{
     background-image: url("../images/video.jpg");
     background-position: center;
-    opacity: 0.7;     
+    opacity: 0.7;
 }
 #video:hover{
     opacity: 1.0;
@@ -68,7 +69,7 @@ p{
 
 #caterer{
     background-image: url("../images/caterer.jpg");
-    background-position: center; 
+    background-position: center;
     opacity: 0.7;
 }
 
@@ -78,7 +79,7 @@ p{
 
 #music{
     background-image: url("../images/guitar.jpg");
-    background-position: center; 
+    background-position: center;
     opacity: 0.7;
 }
 
@@ -88,7 +89,7 @@ p{
 
 #hair{
     background-image: url("../images/hairstyle.jpg");
-    background-position: center; 
+    background-position: center;
     opacity: 0.6;
 }
 
@@ -98,7 +99,7 @@ p{
 
 #tailor{
     background-image: url("../images/tailor.jpg");
-    background-position: center; 
+    background-position: center;
     opacity: 0.6;
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,21 @@
+$(function(){
+  addSignupListener();
+});
+
+function addSignupListener(){
+  $('.toggle-form').click(e => {
+    let $self = $(e.currentTarget);
+    console.log($self);
+
+    $('.toggle-form').removeClass('active-form');
+    $self.addClass('active-form');
+
+    if($self.hasClass('show-vendor')){
+      $('.vendor-signup').show();
+      $('.organizer-signup').hide();
+    }else{
+      $('.vendor-signup').hide();
+      $('.organizer-signup').show();
+    }
+  })
+}

--- a/templates/components/register_inputs.html
+++ b/templates/components/register_inputs.html
@@ -1,0 +1,35 @@
+<input class = 'signup-field {% if usererrors %}error-border{% endif %}'
+type = 'text' placeholder = 'Username' name = 'username' value='{{ username }}'>
+<div class='error-msgs-wrapper'>
+  {% with messages = get_flashed_messages(category_filter=['user_error']) %}
+    {% if messages %}
+      {% for message in messages %}
+        <span class='error'>{{ message }}</span>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+</div>
+<input class = 'signup-field {% if passerrors %}error-border{% endif %}'
+type = 'password' placeholder = 'Password' name = 'password'>
+<div class='error-msgs-wrapper'>
+  {% with messages = get_flashed_messages(category_filter=['pass_error']) %}
+    {% if messages %}
+      {% for message in messages %}
+        <span class='error'>{{ message }}</span>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+</div>
+<input class='signup-field {% if verifyerrors %}error-border{% endif %}'
+        type='password'
+        placeholder='Verify Password'
+        name='verify'>
+<div class='error-msgs-wrapper'>
+  {% with messages = get_flashed_messages(category_filter=['verify_error']) %}
+    {% if messages %}
+      {% for message in messages %}
+        <span class='error'>{{ message }}</span>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+</div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
     <link href="https://fonts.googleapis.com/css?family=Playfair+Display" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Playfair+Display|Raleway" rel="stylesheet">
+    {% block head %} {% endblock %}
   </head>
   <body>
 
@@ -30,7 +31,7 @@
         </div>
       </div>
     </div>
-    
+
     <div id="mainNavbar" class="navbar navbar-dark bg-dark">
       <div class="container d-flex justify-content-between">
         <a href="#" class="navbar-brand">My Wedding Planner</a>
@@ -48,12 +49,12 @@
       </div>
     </footer>
 
-    <!-- Optional JavaScript -->
-    <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js" integrity="sha384-b/U6ypiBEHpOf/4+1nzFpr53nxSS+GLCkfwBdFNTxtclqqenISfwAzpKaMNFNmj4" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-beta/js/bootstrap.min.js" integrity="sha384-h0AbiXch4ZDo7tp9hKZ4TsHbi047NrKGLO3SEJAg45jXxnGIfYzk4Si90RDIqNm1" crossorigin="anonymous"></script>
+
+    <!-- Optional JavaScript -->
+    <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,31 +1,19 @@
-<!DOCTYPE html>
-<html>
-    <body>
-      {% with messages = get_flashed_messages(with_categories=True) %}
-        <ul>
-        {% for category, message in messages %}
-            <li class= "{{category}}">{{message}}</li>
-        {% endfor %}
-        </ul>
- {% endwith %}
-
-<div class='container'>
- 
-  <h2>LOGIN</h2>
- 
-<form  method="POST">
- 
-    <label for='username'>Email(username):</label>
-    <input type="text" name="username" id='username' class='form-control'/>
- 
-    <label for='password'> Password:</label>
-    <input type="password" name="password" id='password' class='form-control'/>
- 
- 
-  <br>
-    <input type="submit"  value="Login"/>
- 
-</form>
+{% extends 'layout.html' %}
+{% block head %}
+    <link type="text/css" href="{{ url_for('static', filename='css/login.css') }}" rel="stylesheet">
+{% endblock %}
+{% block body %}
+<div class="wrapper">
+  <div class='signup-container'>
+    <h2>LOGIN</h2>
+    <form class="form-container-signup" method="POST">
+        <label for='username'>Email(username):</label>
+        <input type="text" name="username" id='username' class='form-control'/>
+        <label for='password'> Password:</label>
+        <input type="password" name="password" id='password' class='form-control'/>
+        <br>
+        <input type="submit"  value="Login"/>
+    </form>
+  </div>
 </div>
-</body>
-</html>
+{% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -19,12 +19,6 @@
           <!-- Grabs the inputs from components/register_inputs.html -->
           {% include 'components/register_inputs.html' %}
           <input name="organizer_signup" class="submit-button" type='submit' value="Sign up"/>
-          <!-- HTML for vendor signup only -->
-          <div class="vendor-only">
-            <label> I wish to sign up as a Vendor
-              <input name="is_vendor" type="checkbox" required>
-            </label>
-          </div>
         </form>
     </div>
 

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -2,12 +2,13 @@
 {% block head %}
     <link type="text/css" href="{{ url_for('static', filename='css/login.css') }}" rel="stylesheet">
 {% endblock %}
-{% block content %}
+{% block body %}
     <!-- TODO: Flexify this page -->
-    <div class = "wrapper">
-        <div class = 'signup-container'>
-            <div class = "form-container-signup">
-                <h1>Sign up</h1>
+    <div class="wrapper">
+        <div class='signup-container'>
+            <!-- Sign up for regular users -->
+            <div class = "form-container-signup organizer-signup">
+                <h1>Organizer</h1>
                 <hr>
                 <form method = 'POST'>
                     <input class = 'signup-field {% if usererrors %}error-border{% endif %}'
@@ -43,6 +44,50 @@
                             {% endfor %}
                         {% endif %}
                     </div>
+                    <input class = "submit-button" type = 'submit' value = "Sign up"/>
+                </form>
+            </div>
+            <!-- Signup for vendors only -->
+            <div class = "form-container-signup vendor-signup">
+                <h1>Vendor</h1>
+                <hr>
+                <form name="vendor-form" method='POST'>
+                    <input class = 'signup-field {% if usererrors %}error-border{% endif %}'
+                    type = 'text' placeholder = 'Username' name = 'username' value='{{ username }}'>
+                    <div class='error-msgs-wrapper'>
+                        {% if usererrors %}
+                            {% for error in usererrors %}
+                                <span class='error'>
+                                    {{ error }}
+                                </span>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                    <input class = 'signup-field {% if passerrors %}error-border{% endif %}'
+                    type = 'password' placeholder = 'Password' name = 'password'>
+                    <div class='error-msgs-wrapper'>
+                        {% if passerrors %}
+                            {% for error in passerrors %}
+                                <span class='error'>
+                                    {{ error }}
+                                </span>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                    <input class = 'signup-field {% if verifyerrors %}error-border{% endif %}'
+                    type = 'password' placeholder = 'Verify Password' name = 'verify'>
+                    <div class='error-msgs-wrapper'>
+                        {% if verifyerrors %}
+                            {% for error in verifyerrors %}
+                                <span class='error'>
+                                    {{ error }}
+                                </span>
+                            {% endfor %}
+                        {% endif %}
+                    </div>
+                    <label> I wish to sign up as a Vendor
+                      <input type="checkbox" value="false" required>
+                    </label>
                     <input class = "submit-button" type = 'submit' value = "Sign up"/>
                 </form>
             </div>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -3,94 +3,42 @@
     <link type="text/css" href="{{ url_for('static', filename='css/login.css') }}" rel="stylesheet">
 {% endblock %}
 {% block body %}
-    <!-- TODO: Flexify this page -->
-    <div class="wrapper">
-        <div class='signup-container'>
-            <!-- Sign up for regular users -->
-            <div class = "form-container-signup organizer-signup">
-                <h1>Organizer</h1>
-                <hr>
-                <form method = 'POST'>
-                    <input class = 'signup-field {% if usererrors %}error-border{% endif %}'
-                    type = 'text' placeholder = 'Username' name = 'username' value='{{ username }}'>
-                    <div class='error-msgs-wrapper'>
-                        {% if usererrors %}
-                            {% for error in usererrors %}
-                                <span class='error'>
-                                    {{ error }}
-                                </span>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
-                    <input class = 'signup-field {% if passerrors %}error-border{% endif %}'
-                    type = 'password' placeholder = 'Password' name = 'password'>
-                    <div class='error-msgs-wrapper'>
-                        {% if passerrors %}
-                            {% for error in passerrors %}
-                                <span class='error'>
-                                    {{ error }}
-                                </span>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
-                    <input class = 'signup-field {% if verifyerrors %}error-border{% endif %}'
-                    type = 'password' placeholder = 'Verify Password' name = 'verify'>
-                    <div class='error-msgs-wrapper'>
-                        {% if verifyerrors %}
-                            {% for error in verifyerrors %}
-                                <span class='error'>
-                                    {{ error }}
-                                </span>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
-                    <input class = "submit-button" type = 'submit' value = "Sign up"/>
-                </form>
-            </div>
-            <!-- Signup for vendors only -->
-            <div class = "form-container-signup vendor-signup">
-                <h1>Vendor</h1>
-                <hr>
-                <form name="vendor-form" method='POST'>
-                    <input class = 'signup-field {% if usererrors %}error-border{% endif %}'
-                    type = 'text' placeholder = 'Username' name = 'username' value='{{ username }}'>
-                    <div class='error-msgs-wrapper'>
-                        {% if usererrors %}
-                            {% for error in usererrors %}
-                                <span class='error'>
-                                    {{ error }}
-                                </span>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
-                    <input class = 'signup-field {% if passerrors %}error-border{% endif %}'
-                    type = 'password' placeholder = 'Password' name = 'password'>
-                    <div class='error-msgs-wrapper'>
-                        {% if passerrors %}
-                            {% for error in passerrors %}
-                                <span class='error'>
-                                    {{ error }}
-                                </span>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
-                    <input class = 'signup-field {% if verifyerrors %}error-border{% endif %}'
-                    type = 'password' placeholder = 'Verify Password' name = 'verify'>
-                    <div class='error-msgs-wrapper'>
-                        {% if verifyerrors %}
-                            {% for error in verifyerrors %}
-                                <span class='error'>
-                                    {{ error }}
-                                </span>
-                            {% endfor %}
-                        {% endif %}
-                    </div>
-                    <label> I wish to sign up as a Vendor
-                      <input type="checkbox" value="false" required>
-                    </label>
-                    <input class = "submit-button" type = 'submit' value = "Sign up"/>
-                </form>
-            </div>
-        </div>
+<!-- TODO: Flexify this page -->
+<div class="wrapper">
+  <h1> Signup </h1>
+  <div class='signup-container'>
+    <div class="signup-tabs">
+      <a href="#" class="toggle-form active-form"> Organizer </a>
+      <span> | </span>
+      <a href="#" class="toggle-form show-vendor"> Vendor </a>
     </div>
+    <hr>
+    <!-- Sign up for regular users -->
+    <div class="form-container-signup organizer-signup">
+        <form method='POST'>
+          <!-- Grabs the inputs from components/register_inputs.html -->
+          {% include 'components/register_inputs.html' %}
+          <input name="organizer_signup" class="submit-button" type='submit' value="Sign up"/>
+          <!-- HTML for vendor signup only -->
+          <div class="vendor-only">
+            <label> I wish to sign up as a Vendor
+              <input name="is_vendor" type="checkbox" required>
+            </label>
+          </div>
+        </form>
+    </div>
+
+    <!-- Sign up for vendor users -->
+    <div class="form-container-signup vendor-signup">
+      <form method='POST'>
+        <!-- Grabs the inputs from components/register_inputs.html -->
+        {% include 'components/register_inputs.html' %}
+        <label> I wish to sign up as a Vendor
+          <input name="is_vendor" type="checkbox" required>
+        </label>
+        <input name="organizer_signup" class="submit-button" type='submit' value="Sign up"/>
+      </form>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -30,7 +30,7 @@
         <label> I wish to sign up as a Vendor
           <input name="is_vendor" type="checkbox" required>
         </label>
-        <input name="organizer_signup" class="submit-button" type='submit' value="Sign up"/>
+        <input name="vendor_signup" class="submit-button" type='submit' value="Sign up"/>
       </form>
     </div>
   </div>

--- a/templates/testSignup.html
+++ b/templates/testSignup.html
@@ -1,6 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <body>
-    <h1>SUCCESS!</h1>
-  </body>
-</html>

--- a/templates/verify_email.html
+++ b/templates/verify_email.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>SUCCESS!</h1>
+    <p>Thank you for signing up. We sent an email to <b>{{session['username']}}</b> to verify your account</p>
+    <p>Once you have verified your email, use the link below to login to your account</p>
+    <a href="/login">Login</a>
+  </body>
+</html>


### PR DESCRIPTION
## What's Happening?
This brings the user and vendor forms into one page and dynamically changes the outcome in the backend based on which form is being submitted

feat: Two seperate registrations for users and vendors
feat: moved forms to a template to reduce repetition
feat: made forms hide/show based on registration type (vendor/organizer)
feat: updated the verification page to show the users email and a link to login
feat: made a check server side to see which register type was being submitted
feat: changed the global font to 'Lato' (do not need to keep, but I like it)

## Testing and Deployment Checklist

- [x] Can switch between forms
- [x] Forms still validate
- [x] Forms still send user to verify_email.html on success
- [x] Backend receives the correct form type (vendor or organizer)