### PR TITLE
feat: sorting on vendor-list now works properly in both asc and desc order

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,6 +1,7 @@
 var api_call_made = false;
 var vendorID = null;
 var sessionDetails = null;
+var vendors = [];
 
 $(function () {
   getSessionDetails();
@@ -57,6 +58,43 @@ function addAjaxListeners() {
     makeSidelinkActive(type);
     getVendorByType(type);
   });
+  $('.sortVendors').on('click', e => {
+    let $self = $(e.currentTarget);
+    let type = $self.attr('data-type');
+    let order = $self.attr('data-order');
+    if(order == 'asc'){
+      vendors = sortArray(vendors, type, 'asc')
+      $self.attr("data-order", 'desc');
+    }else{
+      vendors = sortArray(vendors, type, 'desc')
+      $self.attr("data-order", 'asc');
+    }
+    displayVendors();
+  })
+}
+
+function sortArray(arr, type, order){
+  arr.sort(function(a, b){
+      // a and b will here be two objects from the array
+      // thus a[1] and b[1] will equal the names
+      // if they are equal, return 0 (no sorting)
+      if (a[type] == b[type]) { return 0; }
+      if (a[type] > b[type]){
+          // if a should come after b, return 1
+          if(order == 'asc')
+            return 1;
+          else
+            return -1;
+      }else{
+          // if b should come after a, return -1
+          if(order == 'asc')
+            return -1;
+          else
+            return 1;
+      }
+  });
+
+  return arr;
 }
 
 function getVendorByType(type) {
@@ -78,11 +116,16 @@ function getVendorByType(type) {
     url: '/getvendors',
     data: {
       "type": type
+    },
+    success: function(data){
+      // Convert JSON into an array
+      for(let vendor in data.vendors){
+        vendors.push(data.vendors[vendor]);
+      }
     }
   })
   .done(json => {
-    displayVendors(json);
-    console.log(json);
+    displayVendors();
     api_call_made = false;
   })
 }
@@ -98,12 +141,12 @@ function makeSidelinkActive(type) {
   $('a[href="#' + type + '"]').addClass('is-active');
 }
 
-function displayVendors(json) {
+function displayVendors() {
   let $wrapper = $(".vendor-list-card-wrapper")
 
   $wrapper.empty();
-
-  $.each(json.vendors, function(index, value) {
+  // Use global vendors to allow local sorting
+  $.each(vendors, function(index, value) {
     let $vendorCardWrapper = $("<div />", {"class": "tile is-parent vendor-list-card"});
     let $card = $("<article />", {"class": "tile is-child notification is-info"}).attr("data-vendor-id", value.id);
     $card.append('<div class="overlay"></div>');
@@ -118,6 +161,12 @@ function displayVendors(json) {
       ),
       $("<p />").append(
         $("<small />", {"html": value.city + ", " + value.state})
+      ),
+      $("<p />").append(
+        $("<small />", {"html": 'Rating: ' + value.rating})
+      ),
+      $("<p />").append(
+        $("<small />", {"html": 'Max Price: ' + value.priceMax})
       )
     );
     $vendorCardWrapper.append($card);

--- a/templates/vendor-list.html
+++ b/templates/vendor-list.html
@@ -22,7 +22,7 @@
               <div class="field-body">
                 <div class="field">
                   <div class="control has-icons-left">
-                    <input type="text" id="bookRequestName" class="input is-medium" 
+                    <input type="text" id="bookRequestName" class="input is-medium"
                       readonly>
                     <span class="icon is-left">
                       <i class="mdi mdi-account-circle"></i>
@@ -31,7 +31,7 @@
                 </div>
                 <div class="field">
                   <div class="control has-icons-left">
-                    <input type="text" id="bookRequestBusiness" class="input is-medium" 
+                    <input type="text" id="bookRequestBusiness" class="input is-medium"
                       readonly>
                     <span class="icon is-left">
                       <i class="mdi mdi-account-card-details"></i>
@@ -42,7 +42,7 @@
             </div>
             <div class="field">
               <div id="dateInput" class="control has-icons-left">
-                <input id="bookRequestDate" type="text" class="input is-medium" 
+                <input id="bookRequestDate" type="text" class="input is-medium"
                   placeholder="Pick a date" autocomplete="off">
                 <span class="icon is-left">
                   <i class="mdi mdi-calendar"></i>
@@ -159,22 +159,17 @@
           </p>
           <ul class="menu-list">
             <li>
-              <a role="button" class="getVendorByType" data-type="venue">
-                Price (High to Low)
+              <a role="button" class="sortVendors" data-type="priceMax" data-order="asc">
+                Price
               </a>
             </li>
             <li>
-              <a role="button" class="getVendorByType" data-type="photographer">
-                Price (Low to High)
-              </a>
-            </li>
-            <li>
-              <a role="button" class="getVendorByType" data-type="videographer">
+              <a role="button" class="sortVendors" data-type="state" data-order="asc">
                 Location
               </a>
             </li>
             <li>
-              <a role="button" class="getVendorByType" data-type="caterer">
+              <a role="button" class="sortVendors" data-type="rating" data-order="desc">
                 Rating
               </a>
             </li>


### PR DESCRIPTION
## What's Happening?
This pull will make it so that vendors will be sorted when clicking the sort links on the sidebar of vendor-list

#### Possible Breaking Changes
* There should not be any breaking changes, however I did add some fields to be displayed for each vendor, and changed the list of vendors to be pulled from a global `vendors` array rather than from passed in json to `displayVendors()`

## Related
* Closes issue #58 

## Testing and Deployment Checklist

- [ ] Vendors are correctly sorting when using the links in the sidebar