### PR TITLE
Implement ability to search vendors

### DIFF
--- a/static/css/vendor-list.css
+++ b/static/css/vendor-list.css
@@ -159,6 +159,8 @@
 }
 
 .ajax-loader {
+  display: flex;
+  flex-direction: column;
   position: relative;
   top: 20vh;
 }
@@ -168,6 +170,10 @@
   height: 100px;
   width: 100px;
   position: relative;
+}
+
+.fetch-message {
+  font-size: 0.85rem;
 }
 
 .path {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -173,32 +173,39 @@ var delay = (function() {
 function addSearchListener() {
   $("#vendorSearch").on('keyup', e => {
     let $self = $(e.currentTarget);
+    $('.overlay-container').show();
+    $('.vendor-list-card .overlay').show();
     delay(() => {
       isActiveSearch = $self.val() === "" ? false : true;
       filterArray($self.val());
-    }, 1050);
+      $('.overlay-container').hide();
+      $('.vendor-list-card .overlay').hide();
+    }, 1000);
   });
 }
 
 function filterArray(query) {
+  // Checking to see if anything is in the input box
   if (isActiveSearch) {
     queryResults = []
-    $.each(vendors, (idx, value) => {
-      let strings = [];
-      for (element of Object.values(value)) {
-        if (typeof element == "string") {
-          strings.push(element.toLowerCase());
+    $.each(vendors, (idx, entry) => {
+      // Cycling through entries in each vendor object. If a match is detected in
+      // any of the fields (contact name, business name, address) except email,
+      // it will be added to the queryResults array, then displayed in the view.
+      for (const [key, value] of Object.entries(entry)) {
+        if (key != "email" && typeof value == "string") {
+          if (value.toLowerCase().indexOf(query.toLowerCase()) > -1) {
+            queryResults.push(entry);
+            break;
+          }
         }
       }
-  
-      for (let el of strings) {
-        if (el.indexOf(query.toLowerCase()) > -1) {
-          queryResults.push(value);
-          break;
-        }
-      } 
     });
     displayVendors(queryResults);
+  } else if (!isActiveSearch) {
+    // Showing all results in selected category if there was once an active search and input is now blank
+    queryResults = [];
+    displayVendors(vendors);
   }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -140,9 +140,9 @@
     </div>
   </div>
 </div>
+{% endblock %}
 {% block scripts %}
 <script>
   progressively.init();
 </script>
-{% endblock %}
 {% endblock %}

--- a/templates/vendor-list.html
+++ b/templates/vendor-list.html
@@ -191,6 +191,7 @@
             <svg class="circular">
               <circle class="path" cx="50" cy="50" r="40" fill="none" stroke-width="6" stroke-miterlimit="10"/>
             </svg>
+            <p class="title fetch-message has-text-grey">fetching results...</p>
           </div>
         </div>
         <div class="tile is-ancestor vendor-list-card-wrapper">


### PR DESCRIPTION
## What's Happening?
This branch implements real-time searching in to the vendor list. When you type a query into the search box at the top of the side menu, a JS event will fire that goes through the vendors in the list and finds any matches across some of the fields. For instance, typing in "ca" into the search bar will return vendors with "ca" somewhere in their name, business name, street address and city. That query will also return all vendors located in California (abbr. CA in our SQL setup), and all caterers. The search does not look through email addresses or non-string fields. We may want to refine the behavior a little to restrict the search to only search names, business names, and cities or whatever, but that's an easy thing to fix.

## Left to do
* Display a message when no results could be found based on the query.

## Testing and Deployment Checklist

- [ ] Type anything into the search and see if anything happens, and then look through the search results to see if they're what you expected.
- [ ] Remove your query from the box and see if all the vendors repopulate.
- [ ] Try searching for something that won't give any results, then remove your query to see if vendors show up again.